### PR TITLE
Specify a minimum pyOpenSSL version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ backports.unittest-mock
 click
 docker
 flake8
-pyOpenSSL
+pyOpenSSL>=17.0.0
 requests
 six
 applicationinsights

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open('README.md', 'rb') as f:
 dependencies = [
     'click',
     'docker',
-    'pyOpenSSL',
+    'pyOpenSSL>=17.0.0',
     'requests',
     'six',
     'applicationinsights',


### PR DESCRIPTION
Fix #91 