### PR TITLE
fix docker version issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open('README.md', 'rb') as f:
 
 dependencies = [
     'click',
-    'docker',
+    'docker>=3.6.0',
     'pyOpenSSL>=17.0.0',
     'requests',
     'six',


### PR DESCRIPTION
we require docker-compose version >=1.21.0 which requires docker version >= 3.6.0.
So it should be added into install_requires. 
If not and user got lower version docker on the machine, there is error shows in runtime:
pkg_resources.ContextualVersionConflict: (docker 3.0.0 (c:\python36\lib\site-packages), Requirement.parse('docker<4.0,>=3.6.0'), {'docker-compose'})
