### PR TITLE
Use python 3.7.4 for pyinstaller

### DIFF
--- a/vsts_ci/standalone-binaries/continuous-build-standalone-binaries-win32.yml
+++ b/vsts_ci/standalone-binaries/continuous-build-standalone-binaries-win32.yml
@@ -1,7 +1,8 @@
 steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.x'
+    displayName: 'Use Python 3.7.4'
     inputs:
+      versionSpec: 3.7.4
       architecture: x86
 
   - powershell: |


### PR DESCRIPTION
Use python 3.7.4 for pyinstaller due to issue: https://github.com/pyinstaller/pyinstaller/issues/4311