### PR TITLE
docker runtime support

### DIFF
--- a/iotedgehubdev/compose_parser.py
+++ b/iotedgehubdev/compose_parser.py
@@ -270,7 +270,7 @@ COMPOSE_KEY_CREATE_OPTION_MAPPING = {
     # 'tmpfs:':{'API_Info':'Tmpfs','parser_func':service_parser_naive},
     'userns_mode': {'API_Info': {'UsernsMode': "$['HostConfig']['UsernsMode']"}, 'parser_func': service_parser_naive},
     'isolation': {'API_Info': {'Isolation': "$['HostConfig']['Isolation']"}, 'parser_func': service_parser_naive},
-
+    'runtime': {'API_Info':{'Runtime': "$['HostConfig']['Runtime']"}, 'parser_func': service_parser_naive},
     # Volumes
     'volumes': {
         'API_Info': {

--- a/iotedgehubdev/compose_parser.py
+++ b/iotedgehubdev/compose_parser.py
@@ -270,7 +270,7 @@ COMPOSE_KEY_CREATE_OPTION_MAPPING = {
     # 'tmpfs:':{'API_Info':'Tmpfs','parser_func':service_parser_naive},
     'userns_mode': {'API_Info': {'UsernsMode': "$['HostConfig']['UsernsMode']"}, 'parser_func': service_parser_naive},
     'isolation': {'API_Info': {'Isolation': "$['HostConfig']['Isolation']"}, 'parser_func': service_parser_naive},
-    'runtime': {'API_Info':{'Runtime': "$['HostConfig']['Runtime']"}, 'parser_func': service_parser_naive},
+    'runtime': {'API_Info': {'Runtime': "$['HostConfig']['Runtime']"}, 'parser_func': service_parser_naive},
     # Volumes
     'volumes': {
         'API_Info': {


### PR DESCRIPTION
related issue: https://github.com/Azure/iotedgehubdev/issues/205

For example

```
          "SimulatedTemperatureSensor": {
            "version": "1.0",
            "type": "docker",
            "status": "running",
            "restartPolicy": "always",
            "settings": {
              "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0",
              "createOptions": {              
                "HostConfig": {
                "Runtime": "nvidia"
                }
              }
            }
          }
```

would transfer to:
```
  SimulatedTemperatureSensor:
    container_name: SimulatedTemperatureSensor
    depends_on:
    - edgeHubDev
    environment:
    - EdgeModuleCACertificateFile=c:/mnt/edgemodule/edge-device-ca.cert.pem
    - EdgeHubConnectionString=xxxx
    image: mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0
    labels:
      iotedgehubdev: ''
    networks:
      azure-iot-edge-dev: null
    restart: always
    runtime: nvidia
    volumes:
    - source: edgemoduledev
      target: c:/mnt/edgemodule
      type: volume
```

