### PR TITLE
Add '--pull-all' option to start command

### DIFF
--- a/iotedgehubdev/cli.py
+++ b/iotedgehubdev/cli.py
@@ -228,8 +228,14 @@ def modulecred(modules, local, output_file):
               required=False,
               multiple=True,
               help='Environment variables for single module mode, e.g., `-e "Env1=Value1" -e "Env2=Value2"`.')
+@click.option('--pull-all',
+              required=False,
+              help='Pull all modules specified in deployment manifest even if they already exist',
+              is_flag=True,
+              default=False,
+              show_default=True)
 @_with_telemetry
-def start(inputs, port, deployment, verbose, host, environment):
+def start(inputs, port, deployment, verbose, host, environment, pull_all):
     edge_manager = _parse_config_json()
 
     if edge_manager:
@@ -249,7 +255,7 @@ def start(inputs, port, deployment, verbose, host, environment):
                     module_content = json_data['modulesContent']
                 elif 'moduleContent' in json_data:
                     module_content = json_data['moduleContent']
-            edge_manager.start_solution(module_content, verbose, output)
+            edge_manager.start_solution(module_content, verbose, output, pull_all)
             if not verbose:
                 output.info('IoT Edge Simulator has been started in solution mode.')
         else:

--- a/iotedgehubdev/edgemanager.py
+++ b/iotedgehubdev/edgemanager.py
@@ -174,7 +174,7 @@ class EdgeManager(object):
         compose_project.compose()
         compose_project.dump(target)
 
-    def start_solution(self, module_content, verbose, output):
+    def start_solution(self, module_content, verbose, output, pull_all):
         try:
             EdgeManager.login_registries(module_content)
         except RegistriesLoginError as e:
@@ -195,8 +195,12 @@ class EdgeManager(object):
         except Exception as e:
             output.warning(str(e))
 
-        cmd_pull = ['docker-compose', '-f', EdgeManager.COMPOSE_FILE, 'pull', EdgeManager.EDGEHUB]
+        cmd_pull = ['docker-compose', '-f', EdgeManager.COMPOSE_FILE, 'pull']
+        if not pull_all:
+            # Only pull edgeHub
+            cmd_pull.append(EdgeManager.EDGEHUB)
         Utils.exe_proc(cmd_pull)
+
         if verbose:
             cmd_up = ['docker-compose', '-f', EdgeManager.COMPOSE_FILE, 'up']
         else:


### PR DESCRIPTION
If supplied, the option '--pull-all' will pull all module images specified in
the deployment manifest. If not supplied, only edgeHub will be pulled.

