### PR TITLE
Add support for running on specific version of EdgeHub image

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "module": "pytest",
             "args": [
                 "-v",
-                "${workspaceFolder}/tests/test_cli.py::test_cli_start_with_invalid_edgehub_image_version"
+                "${workspaceFolder}/tests/test_cli.py::test_cli_start_with_custom_edgehub_image_version"
             ],
             "cwd": "${workspaceFolder}",
             "env": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,25 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Python: debug test",
+            "type": "python",
+            "request": "launch",
+            "module": "pytest",
+            "args": [
+                "-v",
+                "${workspaceFolder}/tests/test_cli.py::test_cli_start_with_invalid_edgehub_image_version"
+            ],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "IOTHUB_CONNECTION_STRING": "",
+                "WINDOWS_DEVICE_CONNECTION_STRING": "",
+                "CONTAINER_REGISTRY_SERVER": "",
+                "CONTAINER_REGISTRY_USERNAME": "",
+                "CONTAINER_REGISTRY_PASSWORD": "",
+                "TEST_CA_KEY_PASSPHASE": ""
+             }
+        },
+        {
             "name": "Python Module",
             "type": "python",
             "request": "launch",
@@ -12,9 +31,9 @@
             "module": "iotedgehubdev.cli",
             "args": [
                 // "singlemoduletest"
-                "setup",
-                "--connectionstring",
-                "<DeviceConnstr>"
+                "start",
+                "-img",
+                "1.0.9.4"
             ],
             "debugOptions": [
                 "RedirectOutput"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,4 +10,7 @@
         "test_*.py"
     ],
     "python.testing.nosetestsEnabled": false,
+    "python.linting.pylintEnabled": false,
+    "python.linting.flake8Enabled": true,
+    "python.linting.enabled": true,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,13 @@
 {
-    "python.unitTest.unittestEnabled": true,
-    "python.unitTest.pyTestEnabled": true,
+    "python.testing.unittestEnabled": true,
+    "python.testing.pytestEnabled": false,
+    "python.pythonPath": "c:\\Work\\AzureIoT\\IoTEdge\\IoTEdgeHubDev\\py36venv\\Scripts\\python.exe",
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./tests",
+        "-p",
+        "test_*.py"
+    ],
+    "python.testing.nosetestsEnabled": false,
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [![PyPI version](https://badge.fury.io/py/iotedgehubdev.svg)](https://badge.fury.io/py/iotedgehubdev)
 
+## 0.14.2 - 2020-09-29
+### Added
+* Support for running on specific version of EdgeHub image
+
 ## 0.14.1 - 2020-05-29
 ### Fixed
 * Fix false alarm issue of Windows Defender

--- a/iotedgehubdev/__init__.py
+++ b/iotedgehubdev/__init__.py
@@ -8,6 +8,6 @@ import six  # noqa: F401
 pkg_resources.declare_namespace(__name__)
 
 __author__ = 'Microsoft Corporation'
-__version__ = '0.14.1'
+__version__ = '0.14.2'
 __AIkey__ = '95b20d64-f54f-4de3-8ad5-165a75a6c6fe'
 __production__ = 'iotedgehubdev'

--- a/iotedgehubdev/cli.py
+++ b/iotedgehubdev/cli.py
@@ -222,14 +222,21 @@ def modulecred(modules, local, output_file):
 @click.option('--host',
               '-H',
               required=False,
-              help='Docker daemon socket to connect to')
+              help='Docker daemon socket to connect to.')
 @click.option('--environment',
               '-e',
               required=False,
               multiple=True,
               help='Environment variables for single module mode, e.g., `-e "Env1=Value1" -e "Env2=Value2"`.')
+@click.option('--edgehub-image-version',
+              '-img',
+              required=False,
+              multiple=False,
+              default='1.0',
+              show_default=True,
+              help='EdgeHub image version. Currently supported tags are listed at https://mcr.microsoft.com/v2/azureiotedge-hub/tags/list.')
 @_with_telemetry
-def start(inputs, port, deployment, verbose, host, environment):
+def start(inputs, port, deployment, verbose, host, environment, edgehub_image_version):
     edge_manager = _parse_config_json()
 
     if edge_manager:
@@ -264,7 +271,7 @@ def start(inputs, port, deployment, verbose, host, environment):
                 if re.match(r'^[a-zA-Z][a-zA-Z0-9_]*?=.*$', env) is None:
                     raise ValueError('Environment variable: `{0}` is not valid.'.format(env))
 
-            edge_manager.start_singlemodule(input_list, port, environment)
+            edge_manager.start_singlemodule(input_list, port, environment, edgehub_image_version)
 
             data = '--data \'{{"inputName": "{0}","data":"hello world"}}\''.format(input_list[0])
             url = 'http://localhost:{0}/api/v1/messages'.format(port)

--- a/iotedgehubdev/cli.py
+++ b/iotedgehubdev/cli.py
@@ -234,7 +234,8 @@ def modulecred(modules, local, output_file):
               multiple=False,
               default='1.0',
               show_default=True,
-              help='EdgeHub image version. Currently supported tags are listed at https://mcr.microsoft.com/v2/azureiotedge-hub/tags/list.')
+              help='EdgeHub image version. Currently supported tags '
+              'are listed at https://mcr.microsoft.com/v2/azureiotedge-hub/tags/list.')
 @_with_telemetry
 def start(inputs, port, deployment, verbose, host, environment, edgehub_image_version):
     edge_manager = _parse_config_json()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ Azure IoT EdgeHub Dev Tool
 """
 from setuptools import find_packages, setup
 
-VERSION = '0.14.1'
+VERSION = '0.14.2'
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.
 try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -526,9 +526,10 @@ def test_cli_start_with_invalid_edgehub_image_version(runner):
         result = runner.invoke(cli.start, ['-img', '1.4'])
     finally:
         if result.exit_code == 1:
-            output = result.output.strip()    
+            output = result.output.strip()
             assert 'ERROR: Error during pull for image mcr.microsoft.com/azureiotedge-hub:1.4' in output
-            assert 'manifest for mcr.microsoft.com/azureiotedge-hub:1.4 not found: manifest unknown: manifest tagged by "1.4" is not found' in output
+            assert 'manifest for mcr.microsoft.com/azureiotedge-hub:1.4 not found: ' in output
+            assert 'manifest unknown: manifest tagged by "1.4" is not found' in output
         else:
             raise Exception(result.stdout)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -119,6 +119,7 @@ def cli_start_with_deployment(runner, deployment_json_file_path):
     if 'IoT Edge Simulator has been started in solution mode' not in result.output.strip():
         raise Exception(result.stdout)
 
+
 def invoke_module_method():
     invoke_module_method_cmd = 'az iot hub invoke-module-method --device-id "' + device_id + \
         '" --method-name "reset" --module-id "tempSensor" --hub-name "' + \
@@ -516,7 +517,7 @@ def test_cli_start_with_custom_edgehub_image_version(runner):
         assert 'IoT Edge Simulator has been stopped successfully' in result.output.strip()
         remove_docker_networks(['azure-iot-edge-dev'])
         remove_docker_images(['mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0',
-                              'mcr.microsoft.com/azureiotedge-hub:1.0.9.5',
+                              'mcr.microsoft.com/azureiotedge-hub:1.0.9.4',
                               'hello-world'])
 
 @pytest.mark.skipif(get_docker_os_type() == 'windows', reason='It does not support windows container')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -528,8 +528,7 @@ def test_cli_start_with_invalid_edgehub_image_version(runner):
         if result.exit_code == 1:
             output = result.output.strip()
             assert 'ERROR: Error during pull for image mcr.microsoft.com/azureiotedge-hub:1.4' in output
-            assert 'manifest for mcr.microsoft.com/azureiotedge-hub:1.4 not found: ' in output
-            assert 'manifest unknown: manifest tagged by "1.4" is not found' in output
+            assert 'manifest for mcr.microsoft.com/azureiotedge-hub:1.4 not found' in output
         else:
             raise Exception(result.stdout)
 


### PR DESCRIPTION
Add support for running on specific version of EdgeHub image (#105)

Validation: ran unit tests, added 2 new end to end tests.

Updated version to create a new release if CICD finds no issues.