### PR TITLE
Switch from vs2017-win2016 to windows-2019

### DIFF
--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -7,7 +7,7 @@ jobs:
 
   - job: Windows
     pool:
-      vmImage: vs2017-win2016
+      vmImage: vs2019-win2016
     steps:
       - template: win32/continuous-build-win32.yml
 
@@ -29,7 +29,7 @@ jobs:
       - Windows
       - Linux
     pool:
-      vmImage: vs2017-win2016
+      vmImage: vs2019-win2016
     steps:
       - template: standalone-binaries/continuous-build-standalone-binaries-win32.yml
     condition: and(succeeded('Windows'), succeeded('Linux'), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))

--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -7,7 +7,7 @@ jobs:
 
   - job: Windows
     pool:
-      vmImage: vs2019-win2016
+      vmImage: windows-2019
     steps:
       - template: win32/continuous-build-win32.yml
 
@@ -29,7 +29,7 @@ jobs:
       - Windows
       - Linux
     pool:
-      vmImage: vs2019-win2016
+      vmImage: windows-2019
     steps:
       - template: standalone-binaries/continuous-build-standalone-binaries-win32.yml
     condition: and(succeeded('Windows'), succeeded('Linux'), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))

--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -7,7 +7,7 @@ jobs:
 
   - job: Windows
     pool:
-      vmImage: windows-2019
+      vmImage: vs2017-win2016
     steps:
       - template: win32/continuous-build-win32.yml
 

--- a/vsts_ci/standalone-binaries/continuous-build-standalone-binaries-win32.yml
+++ b/vsts_ci/standalone-binaries/continuous-build-standalone-binaries-win32.yml
@@ -1,8 +1,8 @@
 steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.7.9'
+    displayName: 'Use Python 3.7'
     inputs:
-      versionSpec: 3.7.9
+      versionSpec: 3.7
       architecture: x86
 
   - powershell: |


### PR DESCRIPTION
Switch from vs2017-win2016 to windows-2019 due to temporary incident on vs2017-win2016. This will unblock the publishing step for standalone binaries.