### PR TITLE
Test repackaging iotedgehubdev with latest setuptools

### DIFF
--- a/iotedgehubdev/__init__.py
+++ b/iotedgehubdev/__init__.py
@@ -8,6 +8,6 @@ import six  # noqa: F401
 pkg_resources.declare_namespace(__name__)
 
 __author__ = 'Microsoft Corporation'
-__version__ = '0.14.3-rc'
+__version__ = '0.14.3rc0'
 __AIkey__ = '95b20d64-f54f-4de3-8ad5-165a75a6c6fe'
 __production__ = 'iotedgehubdev'

--- a/iotedgehubdev/__init__.py
+++ b/iotedgehubdev/__init__.py
@@ -8,6 +8,6 @@ import six  # noqa: F401
 pkg_resources.declare_namespace(__name__)
 
 __author__ = 'Microsoft Corporation'
-__version__ = '0.14.2'
+__version__ = '0.14.3-rc'
 __AIkey__ = '95b20d64-f54f-4de3-8ad5-165a75a6c6fe'
 __production__ = 'iotedgehubdev'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ Azure IoT EdgeHub Dev Tool
 """
 from setuptools import find_packages, setup
 
-VERSION = '0.14.3-rc'
+VERSION = '0.14.3rc0'
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.
 try:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ Azure IoT EdgeHub Dev Tool
 """
 from setuptools import find_packages, setup
 
-VERSION = '0.14.3'
+VERSION = '0.14.3-rc'
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.
 try:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ Azure IoT EdgeHub Dev Tool
 """
 from setuptools import find_packages, setup
 
-VERSION = '0.14.2'
+VERSION = '0.14.3'
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.
 try:


### PR DESCRIPTION
This is an rc release to test repackaging iotedgehubdev with the latest setuptools.

Resolving #288 
Root cause is suspected to be https://stackoverflow.com/questions/61574984/no-module-named-pkg-resources-py2-warn-pyinstaller