### PR TITLE
Upgrade setuptools if already present

### DIFF
--- a/iotedgehubdev/__init__.py
+++ b/iotedgehubdev/__init__.py
@@ -8,6 +8,6 @@ import six  # noqa: F401
 pkg_resources.declare_namespace(__name__)
 
 __author__ = 'Microsoft Corporation'
-__version__ = '0.14.3rc0'
+__version__ = '0.14.3rc1'
 __AIkey__ = '95b20d64-f54f-4de3-8ad5-165a75a6c6fe'
 __production__ = 'iotedgehubdev'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ Azure IoT EdgeHub Dev Tool
 """
 from setuptools import find_packages, setup
 
-VERSION = '0.14.3rc0'
+VERSION = '0.14.3rc1'
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.
 try:

--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -57,8 +57,8 @@ jobs:
         displayName: "Replace AI Key for PROD"
 
       - script: |
-          pip install setuptools
-          pip install wheel
+          pip install --upgrade setuptools
+          pip install --upgrade wheel
           pushd $(BUILD.REPOSITORY.LOCALPATH)
           python setup.py bdist_wheel
           popd


### PR DESCRIPTION
Per logs setuptools seems stuck on older version

2020-10-21T07:44:02.4634737Z Requirement already satisfied: setuptools in d:\a\1\s\venv\lib\site-packages (from pyinstaller==3.5->-r requirements.txt (line 18)) (47.1.0)

Fixes https://github.com/Azure/iotedgehubdev/issues/288