### PR TITLE
Force setuptools upgrade to a version 50 or newer

### DIFF
--- a/iotedgehubdev/__init__.py
+++ b/iotedgehubdev/__init__.py
@@ -8,6 +8,6 @@ import six  # noqa: F401
 pkg_resources.declare_namespace(__name__)
 
 __author__ = 'Microsoft Corporation'
-__version__ = '0.14.3rc1'
+__version__ = '0.14.3rc2'
 __AIkey__ = '95b20d64-f54f-4de3-8ad5-165a75a6c6fe'
 __production__ = 'iotedgehubdev'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ Azure IoT EdgeHub Dev Tool
 """
 from setuptools import find_packages, setup
 
-VERSION = '0.14.3rc1'
+VERSION = '0.14.3rc2'
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.
 try:

--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
         displayName: "Replace AI Key for PROD"
 
       - script: |
-          pip install --upgrade setuptools
+          pip install --upgrade setuptools>=50
           pip install --upgrade wheel
           pushd $(BUILD.REPOSITORY.LOCALPATH)
           python setup.py bdist_wheel


### PR DESCRIPTION
Per logs setuptools is still at v47. Adding an explicit condition to upgrade to a version >50.