### PR TITLE
Force setuptools to a newer version

### DIFF
--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -57,8 +57,8 @@ jobs:
         displayName: "Replace AI Key for PROD"
 
       - script: |
-          pip install --upgrade setuptools>=50
-          pip install --upgrade wheel
+          pip install setuptools
+          pip install wheel
           pushd $(BUILD.REPOSITORY.LOCALPATH)
           python setup.py bdist_wheel
           popd

--- a/vsts_ci/standalone-binaries/continuous-build-standalone-binaries-win32.yml
+++ b/vsts_ci/standalone-binaries/continuous-build-standalone-binaries-win32.yml
@@ -16,6 +16,7 @@ steps:
       ((Get-Content -path "$(BUILD.REPOSITORY.LOCALPATH)\iotedgehubdev\__init__.py" -Raw) -replace "__production__ = 'iotedgehubdev'","__production__ = 'iotedgehubdev-standalone'") | Set-Content -Path "$(BUILD.REPOSITORY.LOCALPATH)\iotedgehubdev\__init__.py"
       pip install -e .
       pip install -r requirements.txt
+      pip install --upgrade setuptools>=50
       pyinstaller iotedgehubdev.spec
       $COMPOSE_VER = pip show docker-compose | select-string -Pattern "Version: (\d+\.\d+\.\d+)" | % {$_.Matches.Groups[1].Value}
       Invoke-WebRequest "https://github.com/docker/compose/releases/download/$COMPOSE_VER/docker-compose-Windows-x86_64.exe" -Out "./standalone-binaries/iotedgehubdev/docker-compose.exe"


### PR DESCRIPTION
Force setuptools to a version higher than the cached on the windows-2019 image

#288 