### PR TITLE
Replace deprecated azure-cli-iot-ext with azure-iot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ install:
   - curl -L https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
   - sudo apt-get update
   - sudo apt-get install apt-transport-https azure-cli
-  - az extension add --name azure-cli-iot-ext
+  - az extension add --name azure-iot
   - az --version
 script: sudo `which tox`

--- a/vsts_ci/darwin/continuous-build-darwin.yml
+++ b/vsts_ci/darwin/continuous-build-darwin.yml
@@ -7,7 +7,7 @@ steps:
       architecture: "x64"
 
   - script: |
-      az extension add --name azure-cli-iot-ext
+      az extension add --name azure-iot
       az --version
     displayName: "Install Azure Cli iot extension"
 

--- a/vsts_ci/linux/continuous-build-linux.yml
+++ b/vsts_ci/linux/continuous-build-linux.yml
@@ -9,7 +9,7 @@ steps:
   - script: |
       pip install --upgrade pip
       pip install --upgrade tox
-      az extension add --name azure-cli-iot-ext
+      az extension add --name azure-iot
       az --version
     displayName: "Update and install required tools"
 

--- a/vsts_ci/win32/continuous-build-win32.yml
+++ b/vsts_ci/win32/continuous-build-win32.yml
@@ -2,7 +2,7 @@ steps:
   - powershell: |
       choco install azure-cli
       $env:Path += ";C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin"
-      az extension add --name azure-cli-iot-ext
+      az extension add --name azure-iot
       az --version
     displayName: "Install Azure Cli And Azure Cli Extension"
 


### PR DESCRIPTION
This PR replaces the deprecated azure-cli-iot-ect with the latest azure-iot.

To validate:

Local environment:
a. in a Windows environment, install legacy extension, run all unit tests and make sure they pass [baseline]
b. In same environment, uninstall legacy extension, install latest extension, restart machine, run all unit tests and make sure they pass [baseline]
Pipeline:
a. Run iotedgehubdev pipeline on latest released tag https://dev.azure.com/mseng/VSIoT/_build?definitionId=7735
b. Run iotedgehubdev pipeline on branch with changes and make sure all validation pass.
c. Run Travis pipeline on changes to confirm no issues https://travis-ci.org/github/Azure/iotedgehubdev