### PR TITLE
Incorporate Bandit into pipeline for vulnerability scanning

### DIFF
--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -29,8 +29,6 @@ jobs:
           ruleset: 'guardian'
           verbose: true
           aggregate: 'file'
-      - script: |
-          guardian export
           
   - job: LegalStatusPolicyCheck
     pool:

--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -23,8 +23,9 @@ jobs:
     steps:
       - task: Bandit@1
         inputs:
-          targetsType: 'guardianGlob'
-          targets: 'f|**\*.py;-|.gdn\**'
+          targetsType: 'banditPattern'
+          targetsBandit: '$(Build.SourcesDirectory)'
+          targetsBanditRecursive: true
           ruleset: 'guardian'
           verbose: true
           aggregate: 'file'

--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -29,7 +29,6 @@ jobs:
           ruleset: 'guardian'
           verbose: true
           aggregate: 'file'
-          quiet: true
           
   - job: LegalStatusPolicyCheck
     pool:

--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -89,4 +89,3 @@ jobs:
         inputs:
           pathtoPublish: $(Build.ArtifactStagingDirectory)
           artifactName: build-artifact-drop
-  

--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -29,6 +29,8 @@ jobs:
           ruleset: 'guardian'
           verbose: true
           aggregate: 'file'
+      - script: |
+          for /f %%a IN ('dir /b /s "D:\a\1\.gdn\r\*"') DO cat %%a
           
   - job: LegalStatusPolicyCheck
     pool:

--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -16,6 +16,11 @@ jobs:
       vmImage: ubuntu-16.04
     steps:
       - template: linux/continuous-build-linux.yml
+  
+  - job: ScanForVulnerabilities
+    pool:
+      vmImage: ubuntu-16.04
+    steps:
       - task: Bandit@1
         inputs:
           targetsType: 'guardianGlob'

--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -10,6 +10,9 @@ jobs:
       vmImage: vs2017-win2016
     steps:
       - template: win32/continuous-build-win32.yml
+      - task: SDLNativeRules@2
+        inputs:
+          userProvideBuildInfo: 'auto'
 
   - job: Linux
     pool:
@@ -75,8 +78,3 @@ jobs:
           pathtoPublish: $(Build.ArtifactStagingDirectory)
           artifactName: build-artifact-drop
   
-  - job: CheckForMalware
-    steps:
-    - task: SDLNativeRules@2
-      inputs:
-        userProvideBuildInfo: 'auto'

--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -74,3 +74,9 @@ jobs:
         inputs:
           pathtoPublish: $(Build.ArtifactStagingDirectory)
           artifactName: build-artifact-drop
+  
+  - job: CheckForMalware
+    steps:
+    - task: SDLNativeRules@2
+      inputs:
+        userProvideBuildInfo: 'auto'

--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
   
   - job: ScanForVulnerabilities
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: vs2017-win2016
     steps:
       - task: Bandit@1
         inputs:

--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -29,6 +29,8 @@ jobs:
           ruleset: 'guardian'
           verbose: true
           aggregate: 'file'
+      - script: |
+          guardian export
           
   - job: LegalStatusPolicyCheck
     pool:

--- a/vsts_ci/azure-pipelines.yml
+++ b/vsts_ci/azure-pipelines.yml
@@ -10,16 +10,21 @@ jobs:
       vmImage: vs2017-win2016
     steps:
       - template: win32/continuous-build-win32.yml
-      - task: SDLNativeRules@2
-        inputs:
-          userProvideBuildInfo: 'auto'
 
   - job: Linux
     pool:
       vmImage: ubuntu-16.04
     steps:
       - template: linux/continuous-build-linux.yml
-  
+      - task: Bandit@1
+        inputs:
+          targetsType: 'guardianGlob'
+          targets: 'f|**\*.py;-|.gdn\**'
+          ruleset: 'guardian'
+          verbose: true
+          aggregate: 'file'
+          quiet: true
+          
   - job: LegalStatusPolicyCheck
     pool:
       vmImage: ubuntu-16.04


### PR DESCRIPTION
Use Bandit pipeline tool as primary vulnerability scanner.

Addressing issue https://github.com/Azure/iotedgehubdev/issues/303

Using only base functions now. Can expand functionality as needed. 

Wiki Page:
https://www.1eswiki.com/wiki/Bandit_Build_Task

Github Page:
https://github.com/PyCQA/bandit