### PR TITLE
Hshami/image warning in solution mode

### DIFF
--- a/iotedgehubdev/cli.py
+++ b/iotedgehubdev/cli.py
@@ -28,15 +28,18 @@ GATEWAY_HOST = 'gatewayhost'
 DOCKER_HOST = 'DOCKER_HOST'
 HUB_CONN_STR = 'iothubConnectionString'
 
+# a set of parameters whose given value should be logged
+PARAMS_WITH_VALUES = {'edge_runtime_version'}
 
 @decorators.suppress_all_exceptions()
 def _parse_params(*args, **kwargs):
     params = []
     for key, value in kwargs.items():
-        is_none = '='
         if value is not None:
-            is_none = '!='
-        params.append('{0}{1}None'.format(key, is_none))
+            if key in PARAMS_WITH_VALUES:
+                params.append('{0}={1}'.format(key, value))
+            else:
+                params.append('{0}!=None'.format(key))
     return params
 
 
@@ -228,8 +231,8 @@ def modulecred(modules, local, output_file):
               required=False,
               multiple=True,
               help='Environment variables for single module mode, e.g., `-e "Env1=Value1" -e "Env2=Value2"`.')
-@click.option('--edgehub-image-version',
-              '-img',
+@click.option('--edge_runtime_version',
+              '-er',
               required=False,
               multiple=False,
               default='1.0',
@@ -237,7 +240,7 @@ def modulecred(modules, local, output_file):
               help='EdgeHub image version. Currently supported tags '
               'are listed at https://mcr.microsoft.com/v2/azureiotedge-hub/tags/list.')
 @_with_telemetry
-def start(inputs, port, deployment, verbose, host, environment, edgehub_image_version):
+def start(inputs, port, deployment, verbose, host, environment, edge_runtime_version):
     edge_manager = _parse_config_json()
 
     if edge_manager:
@@ -249,9 +252,10 @@ def start(inputs, port, deployment, verbose, host, environment, edgehub_image_ve
 
         if inputs is None and deployment is not None:
             if len(environment) > 0:
-                output.info('Environment variables are ignored when start IoT Edge Simulator in solution mode.')
+                output.info('Environment variables are ignored in solution mode.')
 
-            if len(edgehub_image_version) > 0:
+            if len(edge_runtime_version) > 0:
+                output.info('edgeHub image version is ignored in solution mode.')
 
             with open(deployment) as json_file:
                 json_data = json.load(json_file)
@@ -263,6 +267,10 @@ def start(inputs, port, deployment, verbose, host, environment, edgehub_image_ve
             if not verbose:
                 output.info('IoT Edge Simulator has been started in solution mode.')
         else:
+            if edge_runtime_version is not None:
+                if re.match(r'^(1\.0)|(1\.1)', edge_runtime_version) is None:
+                    raise ValueError('-edge-runtime-version `{0}` is not valid.'.format(edge_runtime_version))
+
             if deployment is not None:
                 output.info('Deployment manifest is ignored when inputs are present.')
             if inputs is None:
@@ -274,7 +282,7 @@ def start(inputs, port, deployment, verbose, host, environment, edgehub_image_ve
                 if re.match(r'^[a-zA-Z][a-zA-Z0-9_]*?=.*$', env) is None:
                     raise ValueError('Environment variable: `{0}` is not valid.'.format(env))
 
-            edge_manager.start_singlemodule(input_list, port, environment, edgehub_image_version)
+            edge_manager.start_singlemodule(input_list, port, environment, edge_runtime_version)
 
             data = '--data \'{{"inputName": "{0}","data":"hello world"}}\''.format(input_list[0])
             url = 'http://localhost:{0}/api/v1/messages'.format(port)

--- a/iotedgehubdev/cli.py
+++ b/iotedgehubdev/cli.py
@@ -251,6 +251,8 @@ def start(inputs, port, deployment, verbose, host, environment, edgehub_image_ve
             if len(environment) > 0:
                 output.info('Environment variables are ignored when start IoT Edge Simulator in solution mode.')
 
+            if len(edgehub_image_version) > 0:
+
             with open(deployment) as json_file:
                 json_data = json.load(json_file)
                 if 'modulesContent' in json_data:

--- a/iotedgehubdev/cli.py
+++ b/iotedgehubdev/cli.py
@@ -28,18 +28,17 @@ GATEWAY_HOST = 'gatewayhost'
 DOCKER_HOST = 'DOCKER_HOST'
 HUB_CONN_STR = 'iothubConnectionString'
 
-# a set of parameters whose given value should be logged
+# a set of parameters whose value should be logged as given
 PARAMS_WITH_VALUES = {'edge_runtime_version'}
 
 @decorators.suppress_all_exceptions()
 def _parse_params(*args, **kwargs):
     params = []
     for key, value in kwargs.items():
-        if value is not None:
-            if key in PARAMS_WITH_VALUES:
-                params.append('{0}={1}'.format(key, value))
-            else:
-                params.append('{0}!=None'.format(key))
+        if (value is None) or (key in PARAMS_WITH_VALUES):
+            params.append('{0}={1}'.format(key, value))
+        else:
+            params.append('{0}!=None'.format(key))
     return params
 
 
@@ -237,8 +236,7 @@ def modulecred(modules, local, output_file):
               multiple=False,
               default='1.0',
               show_default=True,
-              help='EdgeHub image version. Currently supported tags '
-              'are listed at https://mcr.microsoft.com/v2/azureiotedge-hub/tags/list.')
+              help='EdgeHub image version. Currently supported tags 1.0x or 1.1x')
 @_with_telemetry
 def start(inputs, port, deployment, verbose, host, environment, edge_runtime_version):
     edge_manager = _parse_config_json()
@@ -268,6 +266,7 @@ def start(inputs, port, deployment, verbose, host, environment, edge_runtime_ver
                 output.info('IoT Edge Simulator has been started in solution mode.')
         else:
             if edge_runtime_version is not None:
+                # The only validated versions are 1.0 and 1.1 variants, hence the current limitation
                 if re.match(r'^(1\.0)|(1\.1)', edge_runtime_version) is None:
                     raise ValueError('-edge-runtime-version `{0}` is not valid.'.format(edge_runtime_version))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -505,7 +505,7 @@ def test_cli_start_with_create_options_for_bind(runner):
 def test_cli_start_with_custom_edgehub_image_version(runner):
     try:
         cli_setup(runner)
-        result = runner.invoke(cli.start, ['-img', '1.0'])
+        result = runner.invoke(cli.start, ['-er', '1.0'])
         output = result.output.strip()
         if result.exit_code == 0:
             assert 'IoT Edge Simulator has been started in single module mode' in output
@@ -524,12 +524,11 @@ def test_cli_start_with_custom_edgehub_image_version(runner):
 def test_cli_start_with_invalid_edgehub_image_version(runner):
     try:
         cli_setup(runner)
-        result = runner.invoke(cli.start, ['-img', '1.4'])
+        result = runner.invoke(cli.start, ['-er', '1.4'])
     finally:
         if result.exit_code == 1:
             output = result.output.strip()
-            assert 'ERROR: Error during pull for image mcr.microsoft.com/azureiotedge-hub:1.4' in output
-            assert 'manifest for mcr.microsoft.com/azureiotedge-hub:1.4 not found' in output
+            assert 'ERROR: -edge-runtime-version `1.4` is not valid.' in output
         else:
             raise Exception(result.stdout)
 


### PR DESCRIPTION
- change the option name of edge hub image version to '--edge_runtime_version'/-er'.
- output an informational message when the edge runtime version parameter is specified in solution mode.
- log the provided value for edge runtime version as is in telemetry.
- updated all impacted tests

tested by running tox and ad hoc.