### PR TITLE
make runtime default version 1.1

### DIFF
--- a/iotedgehubdev/__init__.py
+++ b/iotedgehubdev/__init__.py
@@ -8,6 +8,6 @@ import six  # noqa: F401
 pkg_resources.declare_namespace(__name__)
 
 __author__ = 'Microsoft Corporation'
-__version__ = '0.14.6'
+__version__ = '0.14.7rc0'
 __AIkey__ = '95b20d64-f54f-4de3-8ad5-165a75a6c6fe'
 __production__ = 'iotedgehubdev'

--- a/iotedgehubdev/cli.py
+++ b/iotedgehubdev/cli.py
@@ -234,7 +234,7 @@ def modulecred(modules, local, output_file):
               '-er',
               required=False,
               multiple=False,
-              default='1.0',
+              default='1.1',
               show_default=True,
               help='EdgeHub image version. Currently supported tags 1.0x or 1.1x')
 @_with_telemetry

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ Azure IoT EdgeHub Dev Tool
 """
 from setuptools import find_packages, setup
 
-VERSION = '0.14.6'
+VERSION = '0.14.7rc0'
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.
 try:

--- a/tests/assets/config/deployment.json
+++ b/tests/assets/config/deployment.json
@@ -21,7 +21,7 @@
           "edgeAgent": {
             "type": "docker",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-agent:1.1",
               "createOptions": "{}"
             }
           },
@@ -30,7 +30,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-hub:1.1",
               "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"5671/tcp\":[{\"HostPort\":\"5671\"}],\"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
             }
           }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -239,7 +239,7 @@ def test_cli_start_with_deployment(runner):
         assert 'IoT Edge Simulator has been stopped successfully' in result.output.strip()
         remove_docker_networks(['azure-iot-edge-dev'])
         remove_docker_images(['mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0',
-                              'mcr.microsoft.com/azureiotedge-hub:1.0',
+                              'mcr.microsoft.com/azureiotedge-hub:1.1',
                               'hello-world'])
 
 
@@ -394,7 +394,7 @@ def test_cli_create_options_for_custom_volume(runner):
         assert 'IoT Edge Simulator has been stopped successfully' in result.output.strip()
         remove_docker_networks(['azure-iot-edge-dev'])
         remove_docker_images(['mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0',
-                              'mcr.microsoft.com/azureiotedge-hub:1.0',
+                              'mcr.microsoft.com/azureiotedge-hub:1.1',
                               'hello-world'])
         remove_docker_volumes(['testVolume', 'testvolume'])
 
@@ -423,7 +423,7 @@ def test_cli_start_with_chunked_create_options(runner):
         assert 'IoT Edge Simulator has been stopped successfully' in result.output.strip()
         remove_docker_networks(['azure-iot-edge-dev'])
         remove_docker_images(['mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0',
-                              'mcr.microsoft.com/azureiotedge-hub:1.0',
+                              'mcr.microsoft.com/azureiotedge-hub:1.1',
                               'hello-world'])
 
 
@@ -442,7 +442,7 @@ def test_cli_start_with_input(runner):
         result = cli_stop(runner)
         assert 'IoT Edge Simulator has been stopped successfully' in result.output.strip()
         remove_docker_networks(['azure-iot-edge-dev'])
-        remove_docker_images(['mcr.microsoft.com/azureiotedge-hub:1.0',
+        remove_docker_images(['mcr.microsoft.com/azureiotedge-hub:1.1',
                               'mcr.microsoft.com/azureiotedge-testing-utility:1.0.0'])
 
 
@@ -464,7 +464,7 @@ def test_cli_start_with_input_and_host(runner):
         result = runner.invoke(cli.stop, ['-H', docker_host])
         assert 'IoT Edge Simulator has been stopped successfully' in result.output.strip()
         remove_docker_networks(['azure-iot-edge-dev'])
-        remove_docker_images(['mcr.microsoft.com/azureiotedge-hub:1.0',
+        remove_docker_images(['mcr.microsoft.com/azureiotedge-hub:1.1',
                               'mcr.microsoft.com/azureiotedge-testing-utility:1.0.0'])
 
 
@@ -498,14 +498,14 @@ def test_cli_start_with_create_options_for_bind(runner):
         assert 'IoT Edge Simulator has been stopped successfully' in result.output.strip()
         remove_docker_networks(['azure-iot-edge-dev'])
         remove_docker_images(['mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0',
-                              'mcr.microsoft.com/azureiotedge-hub:1.0',
+                              'mcr.microsoft.com/azureiotedge-hub:1.1',
                               'hello-world'])
 
 @pytest.mark.skipif(get_docker_os_type() == 'windows', reason='It does not support windows container')
 def test_cli_start_with_custom_edgehub_image_version(runner):
     try:
         cli_setup(runner)
-        result = runner.invoke(cli.start, ['-er', '1.0'])
+        result = runner.invoke(cli.start, ['-er', '1.1'])
         output = result.output.strip()
         if result.exit_code == 0:
             assert 'IoT Edge Simulator has been started in single module mode' in output

--- a/tests/test_compose_resources/deployment.json
+++ b/tests/test_compose_resources/deployment.json
@@ -15,7 +15,7 @@
           "edgeAgent": {
             "type": "docker",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-agent:1.1",
               "createOptions": ""
             }
           },
@@ -24,7 +24,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-hub:1.1",
               "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
             },
             "env": {

--- a/tests/test_compose_resources/deployment_with_chunked_create_options.json
+++ b/tests/test_compose_resources/deployment_with_chunked_create_options.json
@@ -15,7 +15,7 @@
           "edgeAgent": {
             "type": "docker",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-agent:1.1",
               "createOptions": ""
             }
           },
@@ -23,7 +23,7 @@
             "type": "docker",
             "status": "running",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-hub:1.1",
               "createOptions": "{\"HostConfig\":{\"PortBindings\":",
               "createOptions01": "{\"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
             }

--- a/tests/test_compose_resources/deployment_with_create_options.json
+++ b/tests/test_compose_resources/deployment_with_create_options.json
@@ -16,7 +16,7 @@
           "edgeAgent": {
             "type": "docker",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-agent:1.1",
               "createOptions": ""
             }
           },
@@ -26,7 +26,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-hub:1.1",
               "createOptions": "{\"HostConfig\":{\"PortBindings\":",
               "createOptions01": "{\"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
             }

--- a/tests/test_compose_resources/deployment_with_create_options_for_bind.json
+++ b/tests/test_compose_resources/deployment_with_create_options_for_bind.json
@@ -16,7 +16,7 @@
             "edgeAgent": {
               "type": "docker",
               "settings": {
-                "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
+                "image": "mcr.microsoft.com/azureiotedge-agent:1.1",
                 "createOptions": ""
               }
             },
@@ -26,7 +26,7 @@
               "status": "running",
               "restartPolicy": "always",
               "settings": {
-                "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
+                "image": "mcr.microsoft.com/azureiotedge-hub:1.1",
                 "createOptions": "{\"HostConfig\":{\"PortBindings\":",
                 "createOptions01": "{\"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
               }

--- a/tests/test_compose_resources/deployment_with_custom_volume.json
+++ b/tests/test_compose_resources/deployment_with_custom_volume.json
@@ -16,7 +16,7 @@
           "edgeAgent": {
             "type": "docker",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-agent:1.1",
               "createOptions": "{}"
             }
           },
@@ -26,7 +26,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-hub:1.1",
               "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"5671/tcp\":[{\"HostPort\":\"5671\"}], \"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
             }
           }

--- a/tests/test_compose_resources/deployment_without_custom_module.json
+++ b/tests/test_compose_resources/deployment_without_custom_module.json
@@ -16,7 +16,7 @@
           "edgeAgent": {
             "type": "docker",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-agent:1.1",
               "createOptions": "{}"
             }
           },
@@ -26,7 +26,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-hub:1.1",
               "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"5671/tcp\":[{\"HostPort\":\"5671\"}], \"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
             }
           }

--- a/tests/test_compose_resources/docker-compose.yml
+++ b/tests/test_compose_resources/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     - configSource=local
     - SSL_CERTIFICATE_PATH=/mnt/edgehub/
     - SSL_CERTIFICATE_NAME=edge-hub-server.cert.pfx
-    image: mcr.microsoft.com/azureiotedge-hub:1.0
+    image: mcr.microsoft.com/azureiotedge-hub:1.1
     labels:
       iotedgehubdev: ''
     networks:

--- a/tests/test_compose_resources/docker-compose_with_chunked_create_options.yml
+++ b/tests/test_compose_resources/docker-compose_with_chunked_create_options.yml
@@ -80,7 +80,7 @@ services:
     - configSource=local
     - SSL_CERTIFICATE_PATH=/mnt/edgehub/
     - SSL_CERTIFICATE_NAME=edge-hub-server.cert.pfx
-    image: mcr.microsoft.com/azureiotedge-hub:1.0
+    image: mcr.microsoft.com/azureiotedge-hub:1.1
     labels:
       iotedgehubdev: ''
     networks:


### PR DESCRIPTION
- modify image default to be 1.1
- updated test deployments to use 1.1
- updated the tool's version number to 0.14.7rc0
- ran tox