### PR TITLE
Update display name for GitHub releases

### DIFF
--- a/vsts_ci/standalone-binaries/continuous-build-standalone-binaries-win32.yml
+++ b/vsts_ci/standalone-binaries/continuous-build-standalone-binaries-win32.yml
@@ -28,7 +28,7 @@ steps:
 
   - task: GitHubRelease@0
     inputs:
-      gitHubConnection: 'GitConnection'
+      gitHubConnection: 'github.com_marianan'
       tagPattern: '^v?[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$'
       releaseNotesSource: input
       assets: '$(Build.ArtifactStagingDirectory)/iotedgehubdev-$(VERSION_TAG)-win32-ia32.zip'
@@ -37,7 +37,7 @@ steps:
 
   - task: GitHubRelease@0
     inputs:
-      gitHubConnection: 'GitConnection'
+      gitHubConnection: 'github.com_marianan'
       tagPattern: '^v?[0-9]+\.[0-9]+\.[0-9]+$'
       releaseNotesSource: input
       assets: '$(Build.ArtifactStagingDirectory)/iotedgehubdev-$(VERSION_TAG)-win32-ia32.zip'


### PR DESCRIPTION
Currently the displayed name for iotedgehubdev releases is using the devdiv China team's github connection. With this change it will use the DDE team's display name.