### PR TITLE
Unblock tests on windows for python 3.7

### DIFF
--- a/iotedgehubdev/__init__.py
+++ b/iotedgehubdev/__init__.py
@@ -8,6 +8,6 @@ import six  # noqa: F401
 pkg_resources.declare_namespace(__name__)
 
 __author__ = 'Microsoft Corporation'
-__version__ = '0.14.7'
+__version__ = '0.14.8rc0'
 __AIkey__ = '95b20d64-f54f-4de3-8ad5-165a75a6c6fe'
 __production__ = 'iotedgehubdev'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,15 +5,15 @@ docker[ssh]>=4.4.4
 flake8
 pyOpenSSL>=17.0.0
 python-dotenv
-requests>=2.6.1, !=2.11.0, !=2.12.2, !=2.18.0, <=2.25.
+requests
 six
 applicationinsights
 prompt_toolkit
 rope
 tox
-pyyaml>=3.10, !=3.13, <=5.4
+pyyaml
 jsonpath_rw
-docker-compose>=1.21.0,<=1.26.2
+docker-compose
 pytest
 pyinstaller==3.6
 urllib3>=1.25.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,19 @@
 autopep8
 backports.unittest-mock
 click
-docker[ssh]>=3.6.0,<4.0
+docker[ssh]>=3.6.0
 flake8
 pyOpenSSL>=17.0.0
 python-dotenv
-requests<2.21,>2.19.1
+requests>=2.6.1, !=2.11.0, !=2.12.2, !=2.18.0, <=2.21
 six
 applicationinsights
 prompt_toolkit
 rope
 tox
-pyyaml>=4.1,<=4.2b4
+pyyaml>=3.10, !=3.13, <=5.4
 jsonpath_rw
-docker-compose>=1.21.0,<=1.24.0
+docker-compose>=1.21.0, <=1.26.2
 pytest
-pyinstaller==3.5
+pyinstaller>=3.5
 pywin32==227;platform_system=="Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,15 +5,15 @@ docker[ssh]>=4.4.4
 flake8
 pyOpenSSL>=17.0.0
 python-dotenv
-requests>=2.25.1
+requests>=2.6.1, !=2.11.0, !=2.12.2, !=2.18.0, <=2.25.
 six
 applicationinsights
 prompt_toolkit
 rope
 tox
-pyyaml>=4.2b4,<=5.4
+pyyaml>=3.10, !=3.13, <=5.4
 jsonpath_rw
-docker-compose>=1.21.0,<=1.24.0
+docker-compose>=1.21.0,<=1.26.2
 pytest
 pyinstaller==3.6
 urllib3>=1.25.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,19 @@
 autopep8
 backports.unittest-mock
 click
-docker[ssh]>=3.6.0
+docker[ssh]>=3.6.0,<4.0
 flake8
 pyOpenSSL>=17.0.0
 python-dotenv
-requests>=2.6.1, !=2.11.0, !=2.12.2, !=2.18.0, <=2.21
+requests<2.21,>2.19.1
 six
 applicationinsights
 prompt_toolkit
 rope
 tox
-pyyaml>=3.10, !=3.13, <=5.4
+pyyaml>=4.1,<=4.2b4
 jsonpath_rw
-docker-compose>=1.21.0, <=1.26.2
+docker-compose>=1.21.0,<=1.24.0
 pytest
-pyinstaller<=3.5
+pyinstaller==3.5
 pywin32==227;platform_system=="Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ rope
 tox
 pyyaml>=4.2b4,<=5.4
 jsonpath_rw
-docker-compose>=1.24.0,<=1.28.5
+docker-compose>=1.24.0,<=1.26.2
 pytest
 pyinstaller==3.6
 urllib3>=1.25.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,4 @@ jsonpath_rw
 docker-compose>=1.21.0,<=1.26.2
 pytest
 pyinstaller==3.6
-urllib3>=1.25.9
 pywin32==227;platform_system=="Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,9 +11,9 @@ applicationinsights
 prompt_toolkit
 rope
 tox
-pyyaml==5.4
+pyyaml>=4.2b4,<=5.4
 jsonpath_rw
-docker-compose==1.28.5
+docker-compose>=1.24.0,<=1.28.5
 pytest
 pyinstaller==3.6
 urllib3>=1.25.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ docker[ssh]>=4.4.4
 flake8
 pyOpenSSL>=17.0.0
 python-dotenv
-requests>=2.6.1, !=2.11.0, !=2.12.2, !=2.18.0, <=2.25.1
+requests>=2.6.1, !=2.11.0, !=2.12.2, !=2.18.0, <=2.21
 six
 applicationinsights
 prompt_toolkit
@@ -13,7 +13,7 @@ rope
 tox
 pyyaml>=3.10, !=3.13, <=5.4
 jsonpath_rw
-docker-compose>=1.21.0,<=1.26.2
+docker-compose>=1.21.0, <=1.26.2
 pytest
 pyinstaller==3.6
 pywin32==227;platform_system=="Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ pyyaml>=3.10, !=3.13, <=5.4
 jsonpath_rw
 docker-compose>=1.21.0, <=1.26.2
 pytest
-pyinstaller>=3.5
+pyinstaller<=3.5
 pywin32==227;platform_system=="Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,15 +5,15 @@ docker[ssh]>=4.4.4
 flake8
 pyOpenSSL>=17.0.0
 python-dotenv
-requests
+requests>=2.6.1, !=2.11.0, !=2.12.2, !=2.18.0, <=2.25.1
 six
 applicationinsights
 prompt_toolkit
 rope
 tox
-pyyaml
+pyyaml>=3.10, !=3.13, <=5.4
 jsonpath_rw
-docker-compose
+docker-compose>=1.21.0,<=1.26.2
 pytest
 pyinstaller==3.6
 urllib3>=1.25.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ rope
 tox
 pyyaml>=4.2b4,<=5.4
 jsonpath_rw
-docker-compose>=1.24.0,<=1.26.2
+docker-compose>=1.21.0,<=1.24.0
 pytest
 pyinstaller==3.6
 urllib3>=1.25.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 autopep8
 backports.unittest-mock
 click
-docker[ssh]>=4.4.4
+docker[ssh]>=3.6.0,<4.0
 flake8
 pyOpenSSL>=17.0.0
 python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 autopep8
 backports.unittest-mock
 click
-docker[ssh]>=3.6.0,<4.0
+docker[ssh]>=3.6.0
 flake8
 pyOpenSSL>=17.0.0
 python-dotenv
@@ -15,5 +15,5 @@ pyyaml>=3.10, !=3.13, <=5.4
 jsonpath_rw
 docker-compose>=1.21.0, <=1.26.2
 pytest
-pyinstaller==3.6
+pyinstaller>=3.5
 pywin32==227;platform_system=="Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ pyyaml>=3.10, !=3.13, <=5.4
 jsonpath_rw
 docker-compose>=1.21.0, <=1.26.2
 pytest
-pyinstaller>=3.5
+pyinstaller==3.5
 pywin32==227;platform_system=="Windows"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ Azure IoT EdgeHub Dev Tool
 """
 from setuptools import find_packages, setup
 
-VERSION = '0.14.7'
+VERSION = '0.14.8rc0'
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.
 try:
@@ -32,9 +32,9 @@ dependencies = [
     'requests>=2.25.1',
     'six',
     'applicationinsights',
-    'pyyaml==5.4',
+    'pyyaml>=4.2b4,<=5.4',
     'jsonpath_rw',
-    'docker-compose==1.28.5',
+    'docker-compose>=1.24.0,<=1.28.5',
     'pywin32==227;platform_system=="Windows"'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -27,14 +27,14 @@ with open('README.md', 'rb') as f:
 
 dependencies = [
     'click',
-    'docker[ssh]>=3.6.0',
+    'docker[ssh]>=3.6.0,<4.0',
     'pyOpenSSL>=17.0.0',
-    'requests>=2.6.1, !=2.11.0, !=2.12.2, !=2.18.0',
+    'requests<2.21,>2.19.1',
     'six',
     'applicationinsights',
-    'pyyaml>=3.10, !=3.13, <=5.4',
+    'pyyaml>=4.1,<=4.2b4',
     'jsonpath_rw',
-    'docker-compose>=1.21.0',
+    'docker-compose>=1.21.0,<=1.24.0',
     'pywin32==227;platform_system=="Windows"'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -27,14 +27,14 @@ with open('README.md', 'rb') as f:
 
 dependencies = [
     'click',
-    'docker[ssh]>=4.4.4',
+    'docker[ssh]>=3.6.0',
     'pyOpenSSL>=17.0.0',
-    'requests>=2.6.1, !=2.11.0, !=2.12.2, !=2.18.0, <=2.25.1',
+    'requests>=2.6.1, !=2.11.0, !=2.12.2, !=2.18.0',
     'six',
     'applicationinsights',
     'pyyaml>=3.10, !=3.13, <=5.4',
     'jsonpath_rw',
-    'docker-compose>=1.21.0,<=1.26.2',
+    'docker-compose>=1.21.0',
     'pywin32==227;platform_system=="Windows"'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -29,12 +29,12 @@ dependencies = [
     'click',
     'docker[ssh]>=4.4.4',
     'pyOpenSSL>=17.0.0',
-    'requests>=2.25.1',
+    'requests>=2.6.1, !=2.11.0, !=2.12.2, !=2.18.0, <=2.25.1',
     'six',
     'applicationinsights',
-    'pyyaml>=4.2b4,<=5.4',
+    'pyyaml>=3.10, !=3.13, <=5.4',
     'jsonpath_rw',
-    'docker-compose>=1.21.0,<=1.24.0',
+    'docker-compose>=1.21.0,<=1.26.2',
     'pywin32==227;platform_system=="Windows"'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -29,12 +29,12 @@ dependencies = [
     'click',
     'docker[ssh]>=4.4.4',
     'pyOpenSSL>=17.0.0',
-    'requests>=2.6.1, !=2.11.0, !=2.12.2, !=2.18.0, <=2.25.1',
+    'requests1',
     'six',
     'applicationinsights',
-    'pyyaml>=3.10, !=3.13, <=5.4',
+    'pyyaml',
     'jsonpath_rw',
-    'docker-compose>=1.21.0,<=1.26.2',
+    'docker-compose',
     'pywin32==227;platform_system=="Windows"'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ dependencies = [
     'applicationinsights',
     'pyyaml>=4.2b4,<=5.4',
     'jsonpath_rw',
-    'docker-compose>=1.24.0,<=1.26.2',
+    'docker-compose>=1.21.0,<=1.24.0',
     'pywin32==227;platform_system=="Windows"'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -29,12 +29,12 @@ dependencies = [
     'click',
     'docker[ssh]>=4.4.4',
     'pyOpenSSL>=17.0.0',
-    'requests1',
+    'requests>=2.6.1, !=2.11.0, !=2.12.2, !=2.18.0, <=2.25.1',
     'six',
     'applicationinsights',
-    'pyyaml',
+    'pyyaml>=3.10, !=3.13, <=5.4',
     'jsonpath_rw',
-    'docker-compose',
+    'docker-compose>=1.21.0,<=1.26.2',
     'pywin32==227;platform_system=="Windows"'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ dependencies = [
     'applicationinsights',
     'pyyaml>=4.2b4,<=5.4',
     'jsonpath_rw',
-    'docker-compose>=1.24.0,<=1.28.5',
+    'docker-compose>=1.24.0,<=1.26.2',
     'pywin32==227;platform_system=="Windows"'
 ]
 

--- a/tests/test_edgedockerclient_int.py
+++ b/tests/test_edgedockerclient_int.py
@@ -96,7 +96,6 @@ class TestEdgeDockerClientSmoke(unittest.TestCase):
         with EdgeDockerClient() as client:
             exception_raised = False
             try:
-                self._reset_host_network(client)
                 status = client.status(self.CONTAINER_NAME)
                 if status is not None:
                     self._destroy_container(client)

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps=
     flake8
     python-dotenv
     -rrequirements.txt
-passenv = *
+passenv = * --no-cache-dir
 
 [flake8]
 ignore=E741,E302

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps=
 passenv = *
 setenv = 
     PIP_NO_CACHE_DIR=1
-
+    PIP_FORCE_REINSTALL=1
 
 [flake8]
 ignore=E741,E302

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27, py36, py37
+envlist=py27, py37
 
 [testenv]
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py37
+envlist=py27, py36, py37
 
 [testenv]
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,15 @@ commands=
     flake8
     py.test -s --cov iotedgehubdev {posargs}
 deps=
-    pytest --no-cache-dir
+    pytest
     pytest-cov
     flake8
     python-dotenv
-    -rrequirements.txt --no-cache-dir
-passenv = * 
+    -rrequirements.txt
+passenv = *
+setenv = 
+    PIP_NO_CACHE_DIR=1
+
 
 [flake8]
 ignore=E741,E302

--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,12 @@ commands=
     flake8
     py.test -s --cov iotedgehubdev {posargs}
 deps=
-    pytest
+    pytest --no-cache-dir
     pytest-cov
     flake8
     python-dotenv
-    -rrequirements.txt
-passenv = * --no-cache-dir
+    -rrequirements.txt --no-cache-dir
+passenv = * 
 
 [flake8]
 ignore=E741,E302

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ deps=
 passenv = *
 setenv = 
     PIP_NO_CACHE_DIR=1
-    PIP_USE_FEATURE=2020-resolver
 
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,6 @@ deps=
     python-dotenv
     -rrequirements.txt
 passenv = *
-setenv = 
-    PIP_NO_CACHE_DIR=1
-    PIP_FORCE_REINSTALL=1
 
 [flake8]
 ignore=E741,E302

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps=
 passenv = *
 setenv = 
     PIP_NO_CACHE_DIR=1
+    PIP_USE_FEATURE=2020-resolver
 
 
 [flake8]

--- a/vsts_ci/linux/continuous-build-linux.yml
+++ b/vsts_ci/linux/continuous-build-linux.yml
@@ -9,6 +9,7 @@ steps:
   - script: |
       pip install --upgrade pip
       pip install --upgrade tox
+      pip uninstall -r requirements.txt -y
       az extension add --name azure-iot
       az --version
     displayName: "Update and install required tools"

--- a/vsts_ci/linux/continuous-build-linux.yml
+++ b/vsts_ci/linux/continuous-build-linux.yml
@@ -8,8 +8,8 @@ steps:
 
   - script: |
       pip install --upgrade pip
-      pip install --upgrade tox
       pip uninstall -r requirements.txt -y
+      pip install --upgrade tox
       az extension add --name azure-iot
       az --version
     displayName: "Update and install required tools"

--- a/vsts_ci/win32/continuous-build-win32.yml
+++ b/vsts_ci/win32/continuous-build-win32.yml
@@ -12,8 +12,8 @@ steps:
       choco install python --version 3.7.5
       $env:Path += ";C:\Python37;C:\Python37\Scripts"
       python -m pip install --upgrade pip
-      pip install tox
       pip uninstall -r requirements.txt -y
+      pip install tox
       tox
     displayName: "Run tests against iotedgehubdev source code"
     env:

--- a/vsts_ci/win32/continuous-build-win32.yml
+++ b/vsts_ci/win32/continuous-build-win32.yml
@@ -13,6 +13,7 @@ steps:
       $env:Path += ";C:\Python37;C:\Python37\Scripts"
       python -m pip install --upgrade pip
       pip install tox
+      pip uninstall -r requirements.txt -y
       tox
     displayName: "Run tests against iotedgehubdev source code"
     env:


### PR DESCRIPTION
Remove line in test_edgedockerclient_int.py restarting hns
Credit: @mhshami01 

Tox now passes on windows for py27 and py37