### PR TITLE
Update docker-compose to 1.29.1 to allow Docker 5.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ rope
 tox
 pyyaml>=4.1,<=4.2b4
 jsonpath_rw
-docker-compose==1.28.3
+docker-compose==1.29.1
 pytest
 pyinstaller==4.2
 urllib3>=1.26.4


### PR DESCRIPTION
docker-py is at 5.0.0, so if we install Docker as a clean install this package cannot be installed anymore. (https://docs.docker.com/compose/release-notes/).