### PR TITLE
Remove regex parsing that causes catastrophic backtracking

### DIFF
--- a/iotedgehubdev/compose_parser.py
+++ b/iotedgehubdev/compose_parser.py
@@ -184,23 +184,14 @@ def service_parser_volumes(create_options_details):
     for bind in create_options_details.get('Binds', []):
         target = None
 
-        # Binds should be in the format [source:]destination[:mode]
-        # Windows format and LCOW format are more strict than Linux format due to colons in Windows paths,
-        # so match with them first
-        match = re.match(EdgeConstants.MOUNT_WIN_REGEX, bind) or re.match(EdgeConstants.MOUNT_LCOW_REGEX, bind)
-        if match is not None:
-            source = match.group('source') or ''
-            target = match.group('destination')
-            read_only = match.group('mode') == 'ro'
-        else:
-            # Port of Docker daemon
-            # https://github.com/docker/docker-ce/blob/1c27a55b6259743f35549e96d06334a53d0c0549/components/engine/volume/mounts/linux_parser.go#L18-L28
-            parts = bind.split(':')
-            if len(parts) == 2 or (len(parts) == 3 and parts[2] in ('ro', 'rw', '')):
-                if parts[0] != '':
-                    source = parts[0]
-                    target = parts[1]
-                    read_only = len(parts) == 3 and parts[2] == 'ro'
+        # Port of Docker daemon
+        # https://github.com/docker/docker-ce/blob/1c27a55b6259743f35549e96d06334a53d0c0549/components/engine/volume/mounts/linux_parser.go#L18-L28
+        parts = bind.split(':')
+        if len(parts) == 2 or (len(parts) == 3 and parts[2] in ('ro', 'rw', '')):
+            if parts[0] != '':
+                source = parts[0]
+                target = parts[1]
+                read_only = len(parts) == 3 and parts[2] == 'ro'
 
         if target is not None:
             volume_info = {

--- a/iotedgehubdev/compose_parser.py
+++ b/iotedgehubdev/compose_parser.py
@@ -186,7 +186,7 @@ def service_parser_volumes(create_options_details):
 
         # Port of Docker daemon
         # https://github.com/docker/docker-ce/blob/1c27a55b6259743f35549e96d06334a53d0c0549/components/engine/volume/mounts/linux_parser.go#L18-L28
-        # To catch linux paths 
+        # To catch linux paths
         parts = bind.split(':')
         if len(parts) == 2 or (len(parts) == 3 and parts[2] in ('ro', 'rw', '')):
             if parts[0] != '':

--- a/iotedgehubdev/compose_parser.py
+++ b/iotedgehubdev/compose_parser.py
@@ -187,7 +187,7 @@ def service_parser_volumes(create_options_details):
         # Binds should be in the format [source:]destination[:mode]
         # Windows format and LCOW format are more strict than Linux format due to colons in Windows paths,
         # so match with them first
-        match = re.match(EdgeConstants.MOUNT_WIN_REGEX, bind) 
+        match = re.match(EdgeConstants.MOUNT_WIN_REGEX, bind)
         if match is None:
             # Port of Docker daemon
             # https://github.com/docker/docker-ce/blob/1c27a55b6259743f35549e96d06334a53d0c0549/components/engine/volume/mounts/linux_parser.go#L18-L28
@@ -201,7 +201,7 @@ def service_parser_volumes(create_options_details):
             source = match.group('source') or ''
             target = match.group('destination')
             read_only = match.group('mode') == 'ro'
-            
+
         if target is not None:
             volume_info = {
                 'type': 'bind' if source and os.path.isabs(source) else 'volume',

--- a/iotedgehubdev/compose_parser.py
+++ b/iotedgehubdev/compose_parser.py
@@ -2,11 +2,8 @@
 # Licensed under the MIT License.
 
 import os
-import re
 
 from jsonpath_rw import parse
-
-from .constants import EdgeConstants
 
 
 class CreateOptionParser(object):

--- a/iotedgehubdev/compose_parser.py
+++ b/iotedgehubdev/compose_parser.py
@@ -184,25 +184,24 @@ def service_parser_volumes(create_options_details):
     for bind in create_options_details.get('Binds', []):
         target = None
 
-        # Port of Docker daemon
-        # https://github.com/docker/docker-ce/blob/1c27a55b6259743f35549e96d06334a53d0c0549/components/engine/volume/mounts/linux_parser.go#L18-L28
-        # To catch linux paths
-        parts = bind.split(':')
-        if len(parts) == 2 or (len(parts) == 3 and parts[2] in ('ro', 'rw', '')):
-            if parts[0] != '':
-                source = parts[0]
-                target = parts[1]
-                read_only = len(parts) == 3 and parts[2] == 'ro'
+        # Binds should be in the format [source:]destination[:mode]
+        # Windows format and LCOW format are more strict than Linux format due to colons in Windows paths,
+        # so match with them first
+        match = re.match(EdgeConstants.MOUNT_WIN_REGEX, bind) 
+        if match is None:
+            # Port of Docker daemon
+            # https://github.com/docker/docker-ce/blob/1c27a55b6259743f35549e96d06334a53d0c0549/components/engine/volume/mounts/linux_parser.go#L18-L28
+            parts = bind.split(':')
+            if len(parts) == 2 or (len(parts) == 3 and parts[2] in ('ro', 'rw', '')):
+                if parts[0] != '':
+                    source = parts[0]
+                    target = parts[1]
+                    read_only = len(parts) == 3 and parts[2] == 'ro'
         else:
-            # Binds should be in the format [source:]destination[:mode]
-            # Windows format and LCOW format are more strict than Linux format due to colons in Windows paths,
-            # so match with them first
-            match = re.match(EdgeConstants.MOUNT_WIN_REGEX, bind)
-            if match is not None:
-                source = match.group('source') or ''
-                target = match.group('destination')
-                read_only = match.group('mode') == 'ro'
-
+            source = match.group('source') or ''
+            target = match.group('destination')
+            read_only = match.group('mode') == 'ro'
+            
         if target is not None:
             volume_info = {
                 'type': 'bind' if source and os.path.isabs(source) else 'volume',

--- a/iotedgehubdev/constants.py
+++ b/iotedgehubdev/constants.py
@@ -49,3 +49,4 @@ class EdgeConstants():
     MOUNT_WIN_DEST_REGEX = r'(?P<destination>((?:\\\\\?\\)?([a-z]):((?:[\\/][^\\/:*?"<>\r\n]+)*[\\/]?))|(' + \
         MOUNT_PIPE_REGEX + r'))'
     MOUNT_WIN_REGEX = r'^' + MOUNT_SOURCE_REGEX + MOUNT_WIN_DEST_REGEX + MOUNT_MODE_REGEX + r'$'
+    

--- a/iotedgehubdev/constants.py
+++ b/iotedgehubdev/constants.py
@@ -49,4 +49,3 @@ class EdgeConstants():
     MOUNT_WIN_DEST_REGEX = r'(?P<destination>((?:\\\\\?\\)?([a-z]):((?:[\\/][^\\/:*?"<>\r\n]+)*[\\/]?))|(' + \
         MOUNT_PIPE_REGEX + r'))'
     MOUNT_WIN_REGEX = r'^' + MOUNT_SOURCE_REGEX + MOUNT_WIN_DEST_REGEX + MOUNT_MODE_REGEX + r'$'
-    

--- a/iotedgehubdev/constants.py
+++ b/iotedgehubdev/constants.py
@@ -37,17 +37,3 @@ class EdgeConstants():
         SUBJECT_ORGANIZATION_UNIT_KEY: 'Edge Unit',
         SUBJECT_COMMON_NAME_KEY: 'Edge Test Device CA'
     }
-
-    # Port of Docker daemon
-    # https://github.com/docker/docker-ce/blob/f9756bfb29877236a83979170ef2c0aa35eb57c6/components/engine/volume/mounts/windows_parser.go#L19-L76
-    MOUNT_HOST_DIR_REGEX = r'(?:\\\\\?\\)?[a-z]:[\\/](?:[^\\/:*?"<>|\r\n]+[\\/]?)*'
-    MOUNT_NAME_REGEX = r'[^\\/:*?"<>|\r\n]+'
-    MOUNT_PIPE_REGEX = r'[/\\]{2}.[/\\]pipe[/\\][^:*?"<>|\r\n]+'
-    MOUNT_SOURCE_REGEX = r'((?P<source>((' + MOUNT_HOST_DIR_REGEX + r')|(' + \
-        MOUNT_NAME_REGEX + r')|(' + MOUNT_PIPE_REGEX + r'))):)?'
-    MOUNT_MODE_REGEX = r'(:(?P<mode>(?i)ro|rw))?'
-    MOUNT_WIN_DEST_REGEX = r'(?P<destination>((?:\\\\\?\\)?([a-z]):((?:[\\/][^\\/:*?"<>\r\n]+)*[\\/]?))|(' + \
-        MOUNT_PIPE_REGEX + r'))'
-    MOUNT_LCOW_DEST_REGEX = r'(?P<destination>/(?:[^\\/:*?"<>\r\n]+[/]?)*)'
-    MOUNT_WIN_REGEX = r'^' + MOUNT_SOURCE_REGEX + MOUNT_WIN_DEST_REGEX + MOUNT_MODE_REGEX + r'$'
-    MOUNT_LCOW_REGEX = r'^' + MOUNT_SOURCE_REGEX + MOUNT_LCOW_DEST_REGEX + MOUNT_MODE_REGEX + r'$'

--- a/iotedgehubdev/constants.py
+++ b/iotedgehubdev/constants.py
@@ -37,3 +37,15 @@ class EdgeConstants():
         SUBJECT_ORGANIZATION_UNIT_KEY: 'Edge Unit',
         SUBJECT_COMMON_NAME_KEY: 'Edge Test Device CA'
     }
+
+    # Port of Docker daemon
+    # https://github.com/docker/docker-ce/blob/f9756bfb29877236a83979170ef2c0aa35eb57c6/components/engine/volume/mounts/windows_parser.go#L19-L76
+    MOUNT_HOST_DIR_REGEX = r'(?:\\\\\?\\)?[a-z]:[\\/](?:[^\\/:*?"<>|\r\n]+[\\/]?)*'
+    MOUNT_NAME_REGEX = r'[^\\/:*?"<>|\r\n]+'
+    MOUNT_PIPE_REGEX = r'[/\\]{2}.[/\\]pipe[/\\][^:*?"<>|\r\n]+'
+    MOUNT_SOURCE_REGEX = r'((?P<source>((' + MOUNT_HOST_DIR_REGEX + r')|(' + \
+        MOUNT_NAME_REGEX + r')|(' + MOUNT_PIPE_REGEX + r'))):)?'
+    MOUNT_MODE_REGEX = r'(:(?P<mode>(?i)ro|rw))?'
+    MOUNT_WIN_DEST_REGEX = r'(?P<destination>((?:\\\\\?\\)?([a-z]):((?:[\\/][^\\/:*?"<>\r\n]+)*[\\/]?))|(' + \
+        MOUNT_PIPE_REGEX + r'))'
+    MOUNT_WIN_REGEX = r'^' + MOUNT_SOURCE_REGEX + MOUNT_WIN_DEST_REGEX + MOUNT_MODE_REGEX + r'$'


### PR DESCRIPTION
- Regex parsing of binds in edge deployment manifest takes way too long
- Binds format will always be the same format of "Binds":["<HostStoragePath>:<ModuleStoragePath>"], (https://docs.microsoft.com/en-us/azure/iot-edge/how-to-access-host-storage-from-module?view=iotedge-2020-11#link-module-storage-to-device-storage)
- use existing parsing based on ":" only