### PR TITLE
Use re2 regular expression engine for bind path matching

### DIFF
--- a/iotedgehubdev/compose_parser.py
+++ b/iotedgehubdev/compose_parser.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 import os
-import re
+import re2
 
 from jsonpath_rw import parse
 
@@ -187,7 +187,7 @@ def service_parser_volumes(create_options_details):
         # Binds should be in the format [source:]destination[:mode]
         # Windows format and LCOW format are more strict than Linux format due to colons in Windows paths,
         # so match with them first
-        match = re.match(EdgeConstants.MOUNT_WIN_REGEX, bind) or re.match(EdgeConstants.MOUNT_LCOW_REGEX, bind)
+        match = re2.match(EdgeConstants.MOUNT_WIN_REGEX, bind) or re2.match(EdgeConstants.MOUNT_LCOW_REGEX, bind)
         if match is not None:
             source = match.group('source') or ''
             target = match.group('destination')

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ docker-compose==1.29.1
 pytest
 pyinstaller==4.2
 urllib3>=1.26.4
+pyre2


### PR DESCRIPTION
Use pyre2[1] to allow us to make use of the re2[0] engine. Details in the commit.

[0] https://github.com/google/re2
[1] https://pypi.org/project/pyre2/

The host systems will need re2 and development headers for this, for Ubuntu this can be done with: apt install libre2-dev

This is a solution for:

https://github.com/Azure/iotedgehubdev/issues/366
https://github.com/Azure/iotedgehubdev/issues/352
https://github.com/Azure/iotedgehubdev/issues/287

An alternative is https://github.com/Azure/iotedgehubdev/pull/340, but without this regex some Windows paths may not be recognized.